### PR TITLE
Select the address key according to the email address recorded at Link

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -157,7 +157,11 @@ func (protonDrive *ProtonDrive) _getLinkKRByID(ctx context.Context, linkID strin
 /* The original non-caching version, which resolves the keyring recursively */
 func (protonDrive *ProtonDrive) _getLinkKR(ctx context.Context, link *proton.Link) (*crypto.KeyRing, error) {
 	if link.ParentLinkID == "" { // link is rootLink
-		nodeKR, err := link.GetKeyRing(protonDrive.MainShareKR, protonDrive.AddrKR)
+		signatureVerificationKR, err := protonDrive.getSignatureVerificationKeyring([]string{link.SignatureEmail})
+		if err != nil {
+			return nil, err
+		}
+		nodeKR, err := link.GetKeyRing(protonDrive.MainShareKR, signatureVerificationKR)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +180,11 @@ func (protonDrive *ProtonDrive) _getLinkKR(ctx context.Context, link *proton.Lin
 		return nil, err
 	}
 
-	nodeKR, err := link.GetKeyRing(parentNodeKR, protonDrive.AddrKR)
+	signatureVerificationKR, err := protonDrive.getSignatureVerificationKeyring([]string{link.SignatureEmail})
+	if err != nil {
+		return nil, err
+	}
+	nodeKR, err := link.GetKeyRing(parentNodeKR, signatureVerificationKR)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +236,11 @@ func (protonDrive *ProtonDrive) getLinkKR(ctx context.Context, link *proton.Link
 			return nil, err
 		}
 
-		kr, err := data.link.GetKeyRing(parentNodeKR, protonDrive.AddrKR)
+		signatureVerificationKR, err := protonDrive.getSignatureVerificationKeyring([]string{data.link.SignatureEmail})
+		if err != nil {
+			return nil, err
+		}
+		kr, err := data.link.GetKeyRing(parentNodeKR, signatureVerificationKR)
 		if err != nil {
 			return nil, err
 		}

--- a/common/config.go
+++ b/common/config.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"log"
 	"os"
 	"runtime"
 )
@@ -44,8 +43,6 @@ type ReusableCredentialData struct {
 }
 
 func NewConfigWithDefaultValues() *Config {
-	log.Println("Number of CPUs", runtime.GOMAXPROCS(0))
-
 	return &Config{
 		AppVersion: "",
 		UserAgent:  "",
@@ -77,8 +74,6 @@ func NewConfigWithDefaultValues() *Config {
 }
 
 func NewConfigForIntegrationTests() *Config {
-	log.Println("Number of CPUs", runtime.GOMAXPROCS(0))
-
 	appVersion := os.Getenv("PROTON_API_BRIDGE_APP_VERSION")
 	userAgent := os.Getenv("PROTON_API_BRIDGE_USER_AGENT")
 

--- a/common/keyring.go
+++ b/common/keyring.go
@@ -19,7 +19,7 @@ The address keyrings are encrypted with the primary user keyring at the time.
 
 The primary address key is used to create (encrypt) and retrieve (decrypt) data, e.g. shares
 */
-func getAccountKRs(ctx context.Context, c *proton.Client, keyPass, saltedKeyPass []byte) (*crypto.KeyRing, map[string]*crypto.KeyRing, []proton.Address, []byte, error) {
+func getAccountKRs(ctx context.Context, c *proton.Client, keyPass, saltedKeyPass []byte) (*crypto.KeyRing, map[string]*crypto.KeyRing, map[string]proton.Address, []byte, error) {
 	/* Code taken and modified from proton-bridge */
 
 	user, err := c.GetUser(ctx)
@@ -28,7 +28,7 @@ func getAccountKRs(ctx context.Context, c *proton.Client, keyPass, saltedKeyPass
 	}
 	// log.Printf("user %#v", user)
 
-	addr, err := c.GetAddresses(ctx)
+	addrsArr, err := c.GetAddresses(ctx)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -56,7 +56,7 @@ func getAccountKRs(ctx context.Context, c *proton.Client, keyPass, saltedKeyPass
 		// log.Printf("saltedKeyPass ok")
 	}
 
-	userKR, addrKRs, err := proton.Unlock(user, addr, saltedKeyPass, nil)
+	userKR, addrKRs, err := proton.Unlock(user, addrsArr, saltedKeyPass, nil)
 	if err != nil {
 		return nil, nil, nil, nil, err
 
@@ -66,5 +66,10 @@ func getAccountKRs(ctx context.Context, c *proton.Client, keyPass, saltedKeyPass
 		}
 	}
 
-	return userKR, addrKRs, addr, saltedKeyPass, nil
+	addrs := make(map[string]proton.Address)
+	for _, addr := range addrsArr {
+		addrs[addr.Email] = addr
+	}
+
+	return userKR, addrKRs, addrs, saltedKeyPass, nil
 }

--- a/common/user.go
+++ b/common/user.go
@@ -47,12 +47,12 @@ Log in methods
 Keyring decryption
 The password will be salted, and then used to decrypt the keyring. The salted password needs to be and can be cached, so the keyring can be re-decrypted when needed
 */
-func Login(ctx context.Context, config *Config, authHandler proton.AuthHandler, deAuthHandler proton.Handler) (*proton.Manager, *proton.Client, *ProtonDriveCredential, *crypto.KeyRing, map[string]*crypto.KeyRing, []proton.Address, error) {
+func Login(ctx context.Context, config *Config, authHandler proton.AuthHandler, deAuthHandler proton.Handler) (*proton.Manager, *proton.Client, *ProtonDriveCredential, *crypto.KeyRing, map[string]*crypto.KeyRing, map[string]proton.Address, error) {
 	var c *proton.Client
 	var auth proton.Auth
 	var userKR *crypto.KeyRing
 	var addrKRs map[string]*crypto.KeyRing
-	var addr []proton.Address
+	var addrs map[string]proton.Address
 
 	// get manager
 	m := getProtonManager(config.AppVersion, config.UserAgent)
@@ -71,12 +71,12 @@ func Login(ctx context.Context, config *Config, authHandler proton.AuthHandler, 
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, err
 		}
-		userKR, addrKRs, addr, _, err = getAccountKRs(ctx, c, nil, SaltedKeyPassByteArr)
+		userKR, addrKRs, addrs, _, err = getAccountKRs(ctx, c, nil, SaltedKeyPassByteArr)
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, err
 		}
 
-		return m, c, nil, userKR, addrKRs, addr, nil
+		return m, c, nil, userKR, addrKRs, addrs, nil
 	} else {
 		username := config.FirstLoginCredential.Username
 		password := config.FirstLoginCredential.Password
@@ -119,7 +119,7 @@ func Login(ctx context.Context, config *Config, authHandler proton.AuthHandler, 
 
 		// decrypt keyring
 		var saltedKeyPassByteArr []byte
-		userKR, addrKRs, addr, saltedKeyPassByteArr, err = getAccountKRs(ctx, c, keyPass, nil)
+		userKR, addrKRs, addrs, saltedKeyPassByteArr, err = getAccountKRs(ctx, c, keyPass, nil)
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, err
 		}
@@ -140,7 +140,7 @@ func Login(ctx context.Context, config *Config, authHandler proton.AuthHandler, 
 			AccessToken:   auth.AccessToken,
 			RefreshToken:  auth.RefreshToken,
 			SaltedKeyPass: saltedKeyPass,
-		}, userKR, addrKRs, addr, nil
+		}, userKR, addrKRs, addrs, nil
 	}
 }
 

--- a/error.go
+++ b/error.go
@@ -20,4 +20,5 @@ var (
 	ErrWrongUsageOfGetLinkKR                 = errors.New("internal error for GetLinkKR - nil passed in for link")
 	ErrWrongUsageOfGetLink                   = errors.New("internal error for getLink - empty linkID passed in")
 	ErrSeekOffsetAfterSkippingBlocks         = errors.New("internal error for download seek - the offset after skipping blocks is wrong")
+	ErrNoKeyringForSignatureVerification     = errors.New(("internal error for signature verification - no keyring is generated"))
 )

--- a/file.go
+++ b/file.go
@@ -62,7 +62,11 @@ func (protonDrive *ProtonDrive) GetActiveRevisionAttrs(ctx context.Context, link
 		return nil, err
 	}
 
-	revisionXAttrCommon, err := revisionsMetadata[0].GetDecXAttrString(protonDrive.AddrKR, nodeKR)
+	signatureVerificationKR, err := protonDrive.getSignatureVerificationKeyring([]string{link.FileProperties.ActiveRevision.SignatureEmail})
+	if err != nil {
+		return nil, err
+	}
+	revisionXAttrCommon, err := revisionsMetadata[0].GetDecXAttrString(signatureVerificationKR, nodeKR)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +119,11 @@ func (protonDrive *ProtonDrive) GetActiveRevisionWithAttrs(ctx context.Context, 
 		return nil, nil, err
 	}
 
-	revisionXAttrCommon, err := revision.GetDecXAttrString(protonDrive.AddrKR, nodeKR)
+	signatureVerificationKR, err := protonDrive.getSignatureVerificationKeyring([]string{link.FileProperties.ActiveRevision.SignatureEmail})
+	if err != nil {
+		return nil, nil, err
+	}
+	revisionXAttrCommon, err := revision.GetDecXAttrString(signatureVerificationKR, nodeKR)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/folder_recursive.go
+++ b/folder_recursive.go
@@ -31,7 +31,11 @@ func (protonDrive *ProtonDrive) listDirectoriesRecursively(
 	var currentPath = ""
 
 	if !(excludeRoot && curDepth == 0) {
-		name, err := link.GetName(parentNodeKR, protonDrive.AddrKR)
+		signatureVerificationKR, err := protonDrive.getSignatureVerificationKeyring([]string{link.NameSignatureEmail, link.SignatureEmail})
+		if err != nil {
+			return err
+		}
+		name, err := link.GetName(parentNodeKR, signatureVerificationKR)
 		if err != nil {
 			return err
 		}
@@ -88,7 +92,11 @@ func (protonDrive *ProtonDrive) listDirectoriesRecursively(
 
 			if childrenLinks != nil {
 				// get current node's keyring
-				linkKR, err := link.GetKeyRing(parentNodeKR, protonDrive.AddrKR)
+				signatureVerificationKR, err := protonDrive.getSignatureVerificationKeyring([]string{link.SignatureEmail})
+				if err != nil {
+					return err
+				}
+				linkKR, err := link.GetKeyRing(parentNodeKR, signatureVerificationKR)
 				if err != nil {
 					return err
 				}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/ProtonMail/gluon v0.17.1-0.20230724134000-308be39be96e
 	github.com/ProtonMail/gopenpgp/v2 v2.7.3
-	github.com/henrybear327/go-proton-api v0.0.0-20230905210903-1d7952498156
+	github.com/henrybear327/go-proton-api v0.0.0-20230907193451-e563407504ce
 	github.com/relvacode/iso8601 v1.3.0
 	golang.org/x/sync v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSM
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/henrybear327/go-proton-api v0.0.0-20230905210903-1d7952498156 h1:4AneKd+c3c1Jq9X5FRrbJwqhn5M0lkc38xDuP+nl8M8=
-github.com/henrybear327/go-proton-api v0.0.0-20230905210903-1d7952498156/go.mod h1:w63MZuzufKcIZ93pwRgiOtxMXYafI8H74D77AxytOBc=
+github.com/henrybear327/go-proton-api v0.0.0-20230907193451-e563407504ce h1:n1URi7VYiwX/3akX51keQXi6Huy4lJdVc4biJHYk3iw=
+github.com/henrybear327/go-proton-api v0.0.0-20230907193451-e563407504ce/go.mod h1:w63MZuzufKcIZ93pwRgiOtxMXYafI8H74D77AxytOBc=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=

--- a/mail.go
+++ b/mail.go
@@ -79,7 +79,7 @@ func (protonDrive *ProtonDrive) createDraft(ctx context.Context, config *MailSen
 		},
 	}
 
-	createDraftResp, err := protonDrive.c.CreateDraft(ctx, protonDrive.AddrKR, createDraftReq)
+	createDraftResp, err := protonDrive.c.CreateDraft(ctx, protonDrive.DefaultAddrKR, createDraftReq)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (protonDrive *ProtonDrive) getAttachmentSessionKeyMap(attachments []*proton
 			return nil, err
 		}
 
-		key, err := protonDrive.AddrKR.DecryptSessionKey(keyPacket)
+		key, err := protonDrive.DefaultAddrKR.DecryptSessionKey(keyPacket)
 		if err != nil {
 			return nil, err
 		}
@@ -127,7 +127,7 @@ func (protonDrive *ProtonDrive) uploadAttachments(ctx context.Context, createDra
 			Body: fileByteArray,
 		}
 
-		uploadAttachmentResp, err := protonDrive.c.UploadAttachment(ctx, protonDrive.AddrKR, req)
+		uploadAttachmentResp, err := protonDrive.c.UploadAttachment(ctx, protonDrive.DefaultAddrKR, req)
 		if err != nil {
 			return nil, err
 		}
@@ -172,7 +172,7 @@ func (protonDrive *ProtonDrive) sendDraft(ctx context.Context, messageID string,
 	}
 
 	// for each of the recipient, we encrypt body for them
-	if err = sendReq.AddTextPackage(protonDrive.AddrKR,
+	if err = sendReq.AddTextPackage(protonDrive.DefaultAddrKR,
 		string(htmlTemplate),
 		rfc822.TextHTML,
 		map[string]proton.SendPreferences{config.RecipientEmailAddress: {

--- a/search.go
+++ b/search.go
@@ -51,12 +51,20 @@ func (protonDrive *ProtonDrive) SearchByNameInActiveFolder(
 		return nil, err
 	}
 
-	folderLinkKR, err := folderLink.GetKeyRing(parentNodeKR, protonDrive.AddrKR)
+	signatureVerificationKR, err := protonDrive.getSignatureVerificationKeyring([]string{folderLink.SignatureEmail})
+	if err != nil {
+		return nil, err
+	}
+	folderLinkKR, err := folderLink.GetKeyRing(parentNodeKR, signatureVerificationKR)
 	if err != nil {
 		return nil, err
 	}
 
-	folderHashKey, err := folderLink.GetHashKey(folderLinkKR)
+	signatureVerificationKR, err = protonDrive.getSignatureVerificationKeyring([]string{folderLink.SignatureEmail}, folderLinkKR)
+	if err != nil {
+		return nil, err
+	}
+	folderHashKey, err := folderLink.GetHashKey(folderLinkKR, signatureVerificationKR)
 	if err != nil {
 		return nil, err
 	}

--- a/search_recursive.go
+++ b/search_recursive.go
@@ -73,7 +73,11 @@ func (protonDrive *ProtonDrive) performSearchByNameRecursively(
 		return nil, nil
 	}
 
-	name, err := link.GetName(parentNodeKR, protonDrive.AddrKR)
+	signatureVerificationKR, err := protonDrive.getSignatureVerificationKeyring([]string{link.NameSignatureEmail, link.SignatureEmail})
+	if err != nil {
+		return nil, err
+	}
+	name, err := link.GetName(parentNodeKR, signatureVerificationKR)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +94,11 @@ func (protonDrive *ProtonDrive) performSearchByNameRecursively(
 		// log.Printf("childrenLinks len = %v, %#v", len(childrenLinks), childrenLinks)
 
 		// get current node's keyring
-		linkKR, err := link.GetKeyRing(parentNodeKR, protonDrive.AddrKR)
+		signatureVerificationKR, err := protonDrive.getSignatureVerificationKeyring([]string{link.SignatureEmail})
+		if err != nil {
+			return nil, err
+		}
+		linkKR, err := link.GetKeyRing(parentNodeKR, signatureVerificationKR)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The discussions are here: #3 

The root cause that I currently suspect is that back in the day, address keys used to sign the Links and the File revisions weren't using the primary address key of Share's email address. Instead, the primary email address's address key was used. 

In this PR, we attempted to use the email address associated with the Link or the File revision for the signature verification.