### PR TITLE
Address SHA1 case issue

### DIFF
--- a/file.go
+++ b/file.go
@@ -2,6 +2,7 @@ package proton_api_bridge
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/henrybear327/go-proton-api"
@@ -82,7 +83,7 @@ func (protonDrive *ProtonDrive) GetActiveRevisionAttrs(ctx context.Context, link
 
 	var sha1Hash string
 	if val, ok := revisionXAttrCommon.Digests["SHA1"]; ok {
-		sha1Hash = val
+		sha1Hash = strings.ToLower(val) // https://github.com/henrybear327/Proton-API-Bridge/issues/21 and https://github.com/rclone/rclone/issues/7345#issuecomment-1821463100
 	} else {
 		sha1Hash = ""
 	}


### PR DESCRIPTION
Address SHA1 case issue. 

Related https://github.com/henrybear327/Proton-API-Bridge/issues/21 and https://github.com/rclone/rclone/issues/7345#issuecomment-1821463100

I can't exactly reproduce when Proton returns uppercase SHA1, but it seems that if we set all SHA1 to lower case it should unify the way it's handled later in Rclone: https://github.com/rclone/rclone/blob/c5ff5afc21e818835e953eb424c8744daa1eb49e/fs/operations/operations.go#L119
