### PR TITLE
fix: use the upstream interface name

### DIFF
--- a/file_upload.go
+++ b/file_upload.go
@@ -395,7 +395,7 @@ func (protonDrive *ProtonDrive) commitNewRevision(ctx context.Context, nodeKR *c
 		return err
 	}
 
-	commitRevisionReq := proton.CommitRevisionReq{
+	commitRevisionReq := proton.UpdateRevisionReq{
 		ManifestSignature: manifestSignatureString,
 		SignatureAddress:  protonDrive.signatureAddress,
 	}
@@ -405,7 +405,7 @@ func (protonDrive *ProtonDrive) commitNewRevision(ctx context.Context, nodeKR *c
 		return err
 	}
 
-	err = protonDrive.c.CommitRevision(ctx, protonDrive.MainShare.ShareID, linkID, revisionID, commitRevisionReq)
+	err = protonDrive.c.UpdateRevision(ctx, protonDrive.MainShare.ShareID, linkID, revisionID, commitRevisionReq)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The commit revision naming seems to have been introduced by proton-api-bridge in a custom fork simply due to their personal preferences regarding the API call. This name change functionally breaks backwards compatibility with the upstream proton-go-api, as well as any other tools using proton-go-api. Such breaking changes need to be justified and can not simply be a matter of naming preferences.